### PR TITLE
Configuration correct return types

### DIFF
--- a/testrail_api/_category.py
+++ b/testrail_api/_category.py
@@ -246,7 +246,7 @@ class Configurations(_MetaCategory):
         """
         return self._session.request(METHODS.GET, "get_configs/{}".format(project_id))
 
-    def add_config_group(self, project_id: int, name: str) -> None:
+    def add_config_group(self, project_id: int, name: str) -> dict:
         """
         http://docs.gurock.com/testrail-api2/reference-configs#add_config_group
 
@@ -262,7 +262,7 @@ class Configurations(_MetaCategory):
             METHODS.POST, "add_config_group/{}".format(project_id), json={"name": name}
         )
 
-    def add_config(self, config_group_id: int, name: str) -> None:
+    def add_config(self, config_group_id: int, name: str) -> dict:
         """
         http://docs.gurock.com/testrail-api2/reference-configs#add_config
 
@@ -278,7 +278,7 @@ class Configurations(_MetaCategory):
             METHODS.POST, "add_config/{}".format(config_group_id), json={"name": name}
         )
 
-    def update_config_group(self, config_group_id: int, name: str) -> None:
+    def update_config_group(self, config_group_id: int, name: str) -> dict:
         """
         http://docs.gurock.com/testrail-api2/reference-configs#update_config_group
 
@@ -296,7 +296,7 @@ class Configurations(_MetaCategory):
             json={"name": name},
         )
 
-    def update_config(self, config_id: int, name: str) -> None:
+    def update_config(self, config_id: int, name: str) -> dict:
         """
         http://docs.gurock.com/testrail-api2/reference-configs#update_config
 


### PR DESCRIPTION
Fixing #26 
Per [Gurock documentation](http://docs.gurock.com/testrail-api2/reference-configs), create & update operations on Configuration will return a copy of the modified resource.

Currently, testrail-api returns this data as expected but return type annotation specifies `None` when a `dict` should be returned for the following endpoints:

- /add_config_group
- /add_config
- /update_config_group
- /update_config