### PR TITLE
Casting a boolean to an integer for get requests

### DIFF
--- a/testrail_api/_category.py
+++ b/testrail_api/_category.py
@@ -550,7 +550,8 @@ class Milestones(_MetaCategory):
                 (available since TestRail 4.0).
             :key is_started: int/bool
                 1/True to return started milestones only.
-                0/False to return upcoming milestones only (available since TestRail 5.3).
+                0/False to return upcoming milestones only
+                            (available since TestRail 5.3).
         :return: response
         """
         return self._session.request(

--- a/testrail_api/_category.py
+++ b/testrail_api/_category.py
@@ -544,13 +544,13 @@ class Milestones(_MetaCategory):
         :param project_id:
             The ID of the project
         :param kwargs:
-            :key is_completed:
-                1 to return completed milestones only.
-                0 to return open (active/upcoming) milestones only
+            :key is_completed: int/bool
+                1/True to return completed milestones only.
+                0/False to return open (active/upcoming) milestones only
                 (available since TestRail 4.0).
-            :key is_started:
-                1 to return started milestones only.
-                0 to return upcoming milestones only (available since TestRail 5.3).
+            :key is_started: int/bool
+                1/True to return started milestones only.
+                0/False to return upcoming milestones only (available since TestRail 5.3).
         :return: response
         """
         return self._session.request(
@@ -646,9 +646,9 @@ class Plans(_MetaCategory):
                 Only return test plans created before this date (as UNIX timestamp).
             :key created_by: List[int] or comma-separated string
                 A comma-separated list of creators (user IDs) to filter by.
-            :key is_completed: int
-                1 to return completed test plans only.
-                0 to return active test plans only.
+            :key is_completed: int/bool
+                1/True to return completed test plans only.
+                0/False to return active test plans only.
             :key limit/offset: int
                 Limit the result to :limit test plans. Use :offset to skip records.
             :key milestone_id: List[int] or comma-separated string
@@ -831,9 +831,9 @@ class Projects(_MetaCategory):
         Returns the list of available projects.
 
         :param kwargs: filter
-            :key is_completed: int
-                1 to return completed projects only.
-                0 to return active projects only.
+            :key is_completed: int/bool
+                1/True to return completed projects only.
+                0/False to return active projects only.
         :return: response
         """
         return self._session.request(METHODS.GET, "get_projects", params=kwargs)
@@ -1158,9 +1158,9 @@ class Runs(_MetaCategory):
                 Only return test runs created before this date (as UNIX timestamp).
             :key created_by: List[int] or comma-separated string
                 A comma-separated list of creators (user IDs) to filter by.
-            :key is_completed: int
-                1 to return completed test runs only.
-                0 to return active test runs only.
+            :key is_completed: int/bool
+                1/True to return completed test runs only.
+                0/False to return active test runs only.
             :key limit/offset: int
                 Limit the result to :limit test runs. Use :offset to skip records.
             :key milestone_id: List[int] or comma-separated string

--- a/testrail_api/_session.py
+++ b/testrail_api/_session.py
@@ -38,7 +38,7 @@ class Session:
         :param email:
             Email for the account on the TestRail
         :param password:
-            Password for the account on the TestRail
+            Password for the account on the TestRail or token
         :param exc:
             Catching exceptions
         :param kwargs:
@@ -120,9 +120,14 @@ class Session:
             headers.update({"Content-Type": "application/json"})
 
         if "params" in kwargs:
+            # GET params
             for key, value in kwargs["params"].items():
-                if isinstance(value, list):
+                if isinstance(value, (list, tuple, set)):
+                    # Converting a list to a string '1,2,3'
                     kwargs["params"][key] = ",".join(str(i) for i in value)
+                elif isinstance(value, bool):
+                    # Converting a boolean value to integer
+                    kwargs["params"][key] = int(value)
 
         for count in range(self.__exc_iterations):
             try:

--- a/tests/unit/test_milestone.py
+++ b/tests/unit/test_milestone.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 
+import pytest
 import responses
 
 
@@ -34,14 +35,15 @@ def test_get_milestone(api, mock, host):
     assert response['description'] == 'My new milestone'
 
 
-def test_get_milestones(api, mock, host):
+@pytest.mark.parametrize('is_started', (1, True))
+def test_get_milestones(api, mock, host, is_started):
     mock.add_callback(
         responses.GET,
         '{}index.php?/api/v2/get_milestones/1'.format(host),
         get_milestones,
         content_type='application/json'
     )
-    response = api.milestones.get_milestones(project_id=1, is_started=1)
+    response = api.milestones.get_milestones(project_id=1, is_started=is_started)
     assert response[0]['name'] == 'Milestone 1'
     assert response[0]['description'] == 'My new milestone'
 

--- a/tests/unit/test_plans.py
+++ b/tests/unit/test_plans.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 import responses
 
 
@@ -36,13 +37,14 @@ def test_get_plan(api, mock, host):
     assert resp['id'] == 5
 
 
-def test_get_plans(api, mock, host):
+@pytest.mark.parametrize('is_completed', (1, True))
+def test_get_plans(api, mock, host, is_completed):
     mock.add_callback(
         responses.GET,
         '{}index.php?/api/v2/get_plans/7'.format(host),
         get_plans
     )
-    resp = api.plans.get_plans(7, is_completed=1)
+    resp = api.plans.get_plans(7, is_completed=is_completed)
     assert resp[0]['id'] == 5
 
 

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 import responses
 
 
@@ -28,13 +29,14 @@ def test_get_project(api, mock, host):
     assert resp['name'] == 'Datahub'
 
 
-def test_get_projects(api, mock, host):
+@pytest.mark.parametrize('is_completed', (0, False))
+def test_get_projects(api, mock, host, is_completed):
     mock.add_callback(
         responses.GET,
         '{}index.php?/api/v2/get_projects'.format(host),
         get_projects,
     )
-    resp = api.projects.get_projects(is_completed=0)
+    resp = api.projects.get_projects(is_completed=is_completed)
     assert resp[0]['name'] == 'Datahub'
 
 

--- a/tests/unit/test_runs.py
+++ b/tests/unit/test_runs.py
@@ -1,6 +1,12 @@
 import json
 
+import pytest
 import responses
+
+
+def get_runs(r):
+    assert r.params['is_completed'] == '1'
+    return 200, {}, json.dumps([{'id': 1, 'name': 'My run', 'is_completed': r.params['is_completed']}])
 
 
 def add_run(r):
@@ -20,13 +26,14 @@ def test_get_run(api, mock, host):
     assert resp['id'] == 1
 
 
-def test_get_runs(api, mock, host):
+@pytest.mark.parametrize('is_completed', (1, True))
+def test_get_runs(api, mock, host, is_completed):
     mock.add_callback(
         responses.GET,
         '{}index.php?/api/v2/get_runs/12'.format(host),
-        lambda x: (200, {}, json.dumps([{'id': 1, 'name': 'My run', 'is_completed': x.params['is_completed']}]))
+        get_runs
     )
-    resp = api.runs.get_runs(12, is_completed=1)
+    resp = api.runs.get_runs(12, is_completed=is_completed)
     assert resp[0]['is_completed'] == '1'
 
 


### PR DESCRIPTION
close #41 

`get_runs(projectid=pid, is_completed=False)` equal `get_runs(projectid=pid, is_completed=0)`