### PR TITLE
Fix delete cases api (again)

### DIFF
--- a/testrail_api/__version__.py
+++ b/testrail_api/__version__.py
@@ -1,3 +1,3 @@
 # coding: utf-8
-version = "1.10.4"
-version_tuple = (1, 10, 4)
+version = "1.10.5"
+version_tuple = (1, 10, 5)

--- a/testrail_api/_category.py
+++ b/testrail_api/_category.py
@@ -488,13 +488,13 @@ class Cases(_MetaCategory):
             Including soft=1 will not actually delete the entity.
             Omitting the soft parameter, or submitting soft=0 will delete the test case.
         """
-        params = {"soft": soft, "case_ids": case_ids, "project_id": project_id}
-
+        params = {"soft": soft, "project_id": project_id}
+        body = {"case_ids": case_ids}
         if suite_id:
             url_path = "delete_cases/{}".format(suite_id)
         else:
             url_path = "delete_cases"
-        return self._session.request(METHODS.POST, url_path, params=params)
+        return self._session.request(METHODS.POST, url_path, params=params, json=body)
 
     def copy_cases_to_section(self, section_id: int, case_ids: List[int]):
         """

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -41,7 +41,7 @@ def delete_cases(r, project_id=None, case_ids=None, suite_id=None, soft=0):
     else:
         assert 'delete_cases&' in r.url
     assert json.loads(r.body.decode()) == {'case_ids': case_ids}
-    return 200, {}, r.body.decode()
+    return 200, {}, ''
 
 
 def test_get_case(api, mock, host):

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -36,12 +36,12 @@ def update_cases_suite(r, suite_id=None):
 def delete_cases(r, project_id=None, case_ids=None, suite_id=None, soft=0):
     assert int(r.params['soft']) == soft
     assert int(r.params['project_id']) == project_id
-    assert r.params['case_ids'] == ','.join(map(str, case_ids))
     if suite_id:
         assert 'delete_cases/{}&'.format(suite_id) in r.url
     else:
         assert 'delete_cases&' in r.url
-    return 200, {}, ''
+    assert json.loads(r.body.decode()) == {'case_ids': case_ids}
+    return 200, {}, r.body.decode()
 
 
 def test_get_case(api, mock, host):


### PR DESCRIPTION
I'm not sure why this happened, but apparently they now want the case_ids in the body of the request.

![image](https://user-images.githubusercontent.com/8107880/167004756-61bce3c3-28fb-4eac-af56-c4cf7f52e7fa.png)

This fixes that.

Updated the version this time.

Sorry for the churn @tolstislon 