### PR TITLE
retry on keyerror during requests

### DIFF
--- a/testrail_api/_session.py
+++ b/testrail_api/_session.py
@@ -156,6 +156,14 @@ class Session:
                 response = self.__session.request(
                     method=method.value, url=url, timeout=self.__timeout, **kwargs
                 )
+            except KeyError:
+                if count < self.__exc_iterations - 1:
+                    logger.warning(
+                        "KeyError, retrying %s/%s", count + 1, self.__exc_iterations
+                    )
+                    continue
+                else:
+                    raise
             except Exception as err:
                 logger.error("%s", err, exc_info=True)
                 raise


### PR DESCRIPTION
Pytest sometimes deletes PYTEST_CURRENT_TEST while requests
is calling urllib's getproxies_environment.
This should probably be fixed in urllib.


We see this quite often in fact:
```
03:40:33  ---------------------------- Captured log teardown -----------------------------
03:40:33  06-17-2022 02:00:12 - ERROR: 'PYTEST_CURRENT_TEST'
03:40:33  Traceback (most recent call last):
03:40:33    File "/home/jenkins/workspace/PVS_QA_Automation_main/venv/lib/python3.9/site-packages/testrail_api/_session.py", line 156, in request
03:40:33      response = self.__session.request(
03:40:33    File "/home/jenkins/workspace/PVS_QA_Automation_main/venv/lib/python3.9/site-packages/requests/sessions.py", line 577, in request
03:40:33      settings = self.merge_environment_settings(
03:40:33    File "/home/jenkins/workspace/PVS_QA_Automation_main/venv/lib/python3.9/site-packages/requests/sessions.py", line 759, in merge_environment_settings
03:40:33      env_proxies = get_environ_proxies(url, no_proxy=no_proxy)
03:40:33    File "/home/jenkins/workspace/PVS_QA_Automation_main/venv/lib/python3.9/site-packages/requests/utils.py", line 828, in get_environ_proxies
03:40:33      return getproxies()
03:40:33    File "/nix/store/5bh6rpya1ar6l49vrhx1rg58dsa42906-python3-3.9.6/lib/python3.9/urllib/request.py", line 2498, in getproxies_environment
03:40:33      for name, value in os.environ.items():
03:40:33    File "/nix/store/5bh6rpya1ar6l49vrhx1rg58dsa42906-python3-3.9.6/lib/python3.9/_collections_abc.py", line 850, in __iter__
03:40:33      yield (key, self._mapping[key])
03:40:33    File "/nix/store/5bh6rpya1ar6l49vrhx1rg58dsa42906-python3-3.9.6/lib/python3.9/os.py", line 679, in __getitem__
03:40:33      raise KeyError(key) from None
03:40:33  KeyError: 'PYTEST_CURRENT_TEST'
```

See related patches:
https://github.com/reportportal/client-Python/issues/39
https://github.com/reportportal/client-Python/pull/40
https://github.com/reportportal/client-Python/pull/96