### PR TITLE
Add custom exception retry handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description="Python wrapper of the TestRail API",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version='1.10.6',
+    version="1.11.0",
     install_requires=["requests>=2.20.1"],
     python_requires=">=3.5",
     include_package_data=True,

--- a/testrail_api/__version__.py
+++ b/testrail_api/__version__.py
@@ -1,2 +1,2 @@
 # coding: utf-8
-version = "1.10.6"
+version = "1.11.0"


### PR DESCRIPTION
Closes #71 

Uses the existing retry logic around the KeyError. If custom exceptions are passed, the KeyError is combined with the provided tuple. Else, we just retry on the KeyError as the function did before.

Not sure what version you want to mark this, but I can remove/update the version bump as you see fit. Per SemVer, I would assume this is backward compatible features, bumping the minor version.