### PR TITLE
Add tox.ini to replicate github actions workflow

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+# tox.ini to replicate the github actions environment
+# requires versions of python (latest preferred) in you path as follows:
+# python3.6.x
+# python3.7.x
+# python3.8.x
+# python3.9.x
+# python3.10.x
+
+# Suggestions:
+# Use pyenv to install the python versions
+# pyenv install 3.6.15
+# Create a symlink to the python version you want to use as python3.x
+# ln -s ~/.pyenv/versions/3.6.15/bin/python /usr/local/bin/python3.6
+
+[tox]
+envlist = py36,py37,py38,py39,py310
+
+[testenv]
+deps =
+    flake8
+    pep8-naming
+    pytest
+    black
+    pytest-cov
+    responses
+commands =
+    flake8 testrail_api
+    black --check testrail_api
+    pytest tests


### PR DESCRIPTION
Feel free to reject. I can just store it locally, but thought it would be useful.

Usage:
- Install python versions
- install tox somewhere, e.g. `pipx install tox`
- run `tox`