### PR TITLE
Add support for bulk endpoints #61

### DIFF
--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -102,50 +102,50 @@ def test_get_attachments_for_case(api, mock, url):
     mock.add_callback(
         responses.GET,
         url('get_attachments_for_case/2'),
-        lambda x: (200, {}, json.dumps([{'id': 1, 'filename': '444.jpg'}]))
+        lambda x: (200, {}, json.dumps({"limit": 250, "offset": 250, "size": 1, "attachments": [{'id': 1, 'filename': '444.jpg'}]}))
     )
     resp = api.attachments.get_attachments_for_case(2)
-    assert resp[0]['filename'] == '444.jpg'
+    assert resp.get('attachments')[0]['filename'] == '444.jpg'
 
 
 def test_get_attachments_for_plan(api, mock, url):
     mock.add_callback(
         responses.GET,
         url('get_attachments_for_plan/2'),
-        lambda x: (200, {}, json.dumps([{'id': 1, 'filename': '444.jpg'}]))
+        lambda x: (200, {}, json.dumps({"limit": 250, "offset": 250, "size": 1, "attachments": [{'id': 1, 'filename': '444.jpg'}]}))
     )
     resp = api.attachments.get_attachments_for_plan(2)
-    assert resp[0]['filename'] == '444.jpg'
+    assert resp.get('attachments')[0]['filename'] == '444.jpg'
 
 
 def test_get_attachments_for_plan_entry(api, mock, url):
     mock.add_callback(
         responses.GET,
         url('get_attachments_for_plan_entry/2/1'),
-        lambda x: (200, {}, json.dumps([{'id': 1, 'filename': '444.jpg'}]))
+        lambda x: (200, {}, json.dumps({"limit": 250, "offset": 250, "size": 1, "attachments": [{'id': 1, 'filename': '444.jpg'}]}))
     )
     resp = api.attachments.get_attachments_for_plan_entry(2, 1)
-    assert resp[0]['filename'] == '444.jpg'
+    assert resp.get('attachments')[0]['filename'] == '444.jpg'
 
 
 def test_get_attachments_for_run(api, mock, url):
     mock.add_callback(
         responses.GET,
         url('get_attachments_for_run/2'),
-        lambda x: (200, {}, json.dumps([{'id': 1, 'filename': '444.jpg'}]))
+        lambda x: (200, {}, json.dumps({"limit": 250, "offset": 250, "size": 1, "attachments": [{'id': 1, 'filename': '444.jpg'}]}))
     )
     resp = api.attachments.get_attachments_for_run(2)
-    assert resp[0]['filename'] == '444.jpg'
+    assert resp.get('attachments')[0]['filename'] == '444.jpg'
 
 
 def test_get_attachments_for_test(api, mock, url):
     mock.add_callback(
         responses.GET,
         url('get_attachments_for_test/12'),
-        lambda x: (200, {}, json.dumps([{'id': 1, 'filename': '444.jpg'}]))
+        lambda x: (200, {}, json.dumps({"limit": 250, "offset": 250, "size": 1, "attachments": [{'id': 1, 'filename': '444.jpg'}]}))
     )
     resp = api.attachments.get_attachments_for_test(12)
-    assert resp[0]['filename'] == '444.jpg'
+    assert resp.get('attachments')[0]['filename'] == '444.jpg'
 
 
 def test_get_attachment(api, mock, url, base_path):
@@ -192,3 +192,48 @@ def test_delete_attachment(api, mock, url):
     )
     resp = api.attachments.delete_attachment(433)
     assert resp is None
+
+def test_get_attachments_for_case_bulk(api, mock, url):
+    mock.add_callback(
+        responses.GET,
+        url('get_attachments_for_case/2'),
+        lambda x: (200, {}, json.dumps({"limit": 250, "offset": 250, "size": 1, "attachments": [{'id': 1, 'filename': '444.jpg'}]}))
+    )
+    resp = api.attachments.get_attachments_for_case_bulk(2)
+    assert resp[0]['filename'] == '444.jpg'
+
+def test_get_attachments_for_plan_bulk(api, mock, url):
+    mock.add_callback(
+        responses.GET,
+        url('get_attachments_for_plan/2'),
+        lambda x: (200, {}, json.dumps({"limit": 250, "offset": 250, "size": 1, "attachments": [{'id': 1, 'filename': '444.jpg'}]}))
+    )
+    resp = api.attachments.get_attachments_for_plan_bulk(2)
+    assert resp[0]['filename'] == '444.jpg'
+
+def test_get_attachments_for_run_bulk(api, mock, url):
+    mock.add_callback(
+        responses.GET,
+        url('get_attachments_for_run/2'),
+        lambda x: (200, {}, json.dumps({"limit": 250, "offset": 250, "size": 1, "attachments": [{'id': 1, 'filename': '444.jpg'}]}))
+    )
+    resp = api.attachments.get_attachments_for_run_bulk(2)
+    assert resp[0]['filename'] == '444.jpg'
+
+def test_get_attachments_for_plan_entry_bulk(api, mock, url):
+    mock.add_callback(
+        responses.GET,
+        url('get_attachments_for_plan_entry/2/1'),
+        lambda x: (200, {}, json.dumps({"limit": 250, "offset": 250, "size": 1, "attachments": [{'id': 1, 'filename': '444.jpg'}]}))
+    )
+    resp = api.attachments.get_attachments_for_plan_entry_bulk(2, 1)
+    assert resp[0]['filename'] == '444.jpg'
+
+def test_get_attachments_for_test_bulk(api, mock, url):
+    mock.add_callback(
+        responses.GET,
+        url('get_attachments_for_test/2'),
+        lambda x: (200, {}, json.dumps({"limit": 250, "offset": 250, "size": 1, "attachments": [{'id': 1, 'filename': '444.jpg'}]}))
+    )
+    resp = api.attachments.get_attachments_for_test_bulk(2)
+    assert resp[0]['filename'] == '444.jpg'

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -13,7 +13,7 @@ def get_cases(r):
     assert r.params["offset"]
     for key in "created_after", "created_before", "updated_after", "updated_before":
         assert re.match(r"^\d+$", r.params[key])
-    return 200, {}, json.dumps([{"id": 1, "type_id": 1, "title": "My case"}])
+    return 200, {}, json.dumps({"limit": 250, "offset": 250, "size": 1, "cases":[{"id": 1, "type_id": 1, "title": "My case"}]})
 
 
 def add_case(r):
@@ -95,7 +95,7 @@ def test_get_cases(api, mock, url):
         updated_after=now,
         updated_before=now,
     )
-    assert resp[0]["id"] == 1
+    assert resp.get('cases')[0]["id"] == 1
 
 
 def test_add_case(api, mock, url):
@@ -195,3 +195,24 @@ def test_move_cases_to_section(api, mock, url):
     )
     resp = api.cases.move_cases_to_section(section_or_suite_id=5, case_ids=[1, 2, 3])
     assert resp["case_ids"] == "1,2,3"
+
+def test_get_cases_bulk(api, mock, url):
+    mock.add_callback(
+        responses.GET,
+        url("get_cases/1"),
+        get_cases,
+    )
+    now = datetime.now()
+
+    resp = api.cases.get_cases_bulk(
+        1,
+        suite_id=2,
+        section_id=3,
+        limit=5,
+        offset=10,
+        created_after=now,
+        created_before=round(now.timestamp()),
+        updated_after=now,
+        updated_before=now,
+    )
+    assert resp[0]["id"] == 1

--- a/tests/test_milestone.py
+++ b/tests/test_milestone.py
@@ -17,7 +17,7 @@ def get_milestones(r):
     req = r.params
     assert req['is_started'] == '1'
     return 200, {}, json.dumps(
-        [{'id': 1, 'name': 'Milestone 1', 'description': 'My new milestone'}]
+        {"offset": 250, "limit": 250, "size": 1, "milestones": [{'id': 1, 'name': 'Milestone 1', 'description': 'My new milestone'}]}
     )
 
 
@@ -49,7 +49,7 @@ def test_get_milestones(api, mock, url, is_started):
         get_milestones,
         content_type='application/json'
     )
-    response = api.milestones.get_milestones(project_id=1, is_started=is_started)
+    response = api.milestones.get_milestones(project_id=1, is_started=is_started).get('milestones')
     assert response[0]['name'] == 'Milestone 1'
     assert response[0]['description'] == 'My new milestone'
 
@@ -94,3 +94,15 @@ def test_delete_milestone(api, mock, url):
     )
     response = api.milestones.delete_milestone(1)
     assert response is None
+
+
+def test_get_milestones_bulk(api, mock, url):
+    mock.add_callback(
+        responses.GET,
+        url('get_milestones/1'),
+        get_milestones,
+        content_type='application/json'
+    )
+    response = api.milestones.get_milestones_bulk(1, is_started=1)
+    assert response[0]['name'] == 'Milestone 1'
+    assert response[0]['description'] == 'My new milestone'

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -10,7 +10,7 @@ def get_plans(r):
     assert r.params['is_completed'] == '1'
     for key in 'created_after', 'created_before':
         assert re.match(r'^\d+$', r.params[key])
-    return 200, {}, json.dumps([{'id': 5, 'name': 'System test'}])
+    return 200, {}, json.dumps({"offset": 0, "limit": 250, "size": 1, "plans": [{"id": 5, "name": "System test"}]})
 
 
 def add_plan(r):
@@ -65,7 +65,7 @@ def test_get_plans(api, mock, url, is_completed):
     resp = api.plans.get_plans(
         7, is_completed=is_completed, created_after=datetime.now(),
         created_before=datetime.now()
-    )
+    ).get('plans')
     assert resp[0]['id'] == 5
 
 
@@ -166,3 +166,16 @@ def test_delete_run_from_plan_entry(api, mock, url):
         lambda x: (200, {}, '')
     )
     api.plans.delete_run_from_plan_entry(2)
+
+def test_get_plans_bulk(api, mock, url):
+    mock.add_callback(
+        responses.GET,
+        url('get_plans/1'),
+        get_plans,
+    )
+    resp = api.plans.get_plans_bulk(1,
+                is_completed=True,
+                created_after=datetime.now(),
+                created_before=datetime.now(),
+                )
+    assert resp[0]['id'] == 5

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -24,9 +24,17 @@ def test_get_sections(api, mock, url):
     mock.add_callback(
         responses.GET,
         url('get_sections/5'),
-        lambda x: (200, {}, json.dumps([{'depth': 1, 'description': 'My section'}]))
+        lambda x: (200, {}, json.dumps(
+                {
+                    'offset': 0,
+                    'limit': 250,
+                    'size': 1,
+                    'sections':[{'depth': 1, 'description': 'My section'}],
+                }
+            )
+        )
     )
-    resp = api.sections.get_sections(5, suite_id=2)
+    resp = api.sections.get_sections(5, suite_id=2).get('sections')
     assert resp[0]['depth'] == 1
 
 
@@ -73,3 +81,20 @@ def test_move_section(api, mock, url):
     resp = api.sections.move_section(2, parent_id=3, after_id=5)
     assert resp['parent_id'] == 3
     assert resp['after_id'] == 5
+
+def test_get_sections_bulk(api, mock, url):
+    mock.add_callback(
+        responses.GET,
+        url('get_sections/5'),
+        lambda x: (200, {}, json.dumps(
+                {
+                    'offset': 0,
+                    'limit': 250,
+                    'size': 1,
+                    'sections':[{'depth': 1, 'description': 'My section'}],
+                }
+            )
+        )
+    )
+    resp = api.sections.get_sections_bulk(5, suite_id=2)
+    assert resp[0]['depth'] == 1

--- a/tests/test_shared_steps.py
+++ b/tests/test_shared_steps.py
@@ -24,11 +24,19 @@ def test_get_shared_steps(api, mock, url):
     mock.add_callback(
         responses.GET,
         url('get_shared_steps/1'),
-        lambda x: (200, {}, json.dumps({'id': 1, 'title': 'My step'}))
+        lambda x: (200, {}, json.dumps(
+                {
+                    'offset': 0,
+                    'limit': 250,
+                    'size': 1,
+                    'shared_steps': [{'id': 1, 'title': 'My step'}],
+                }
+            )
+        )
     )
-    resp = api.shared_steps.get_shared_steps(project_id=1)
-    assert resp['id'] == 1
-    assert resp['title'] == 'My step'
+    resp = api.shared_steps.get_shared_steps(project_id=1).get('shared_steps')
+    assert resp[0]['id'] == 1
+    assert resp[0]['title'] == 'My step'
 
 
 def test_add_shared_step(api, mock, url):
@@ -64,3 +72,22 @@ def test_delete_shared_step(api, mock, url):
         lambda x: (200, {}, '')
     )
     api.shared_steps.delete_shared_step(shared_update_id=34)
+
+
+def test_get_shared_steps_bulk(api, mock, url):
+    mock.add_callback(
+        responses.GET,
+        url('get_shared_steps/1'),
+        lambda x: (200, {}, json.dumps(
+                {
+                    'offset': 0,
+                    'limit': 250,
+                    'size': 1,
+                    'shared_steps': [{'id': 1, 'title': 'My step'}],
+                }
+            )
+        )
+    )
+    resp = api.shared_steps.get_shared_steps_bulk(project_id=1)
+    assert resp[0]['id'] == 1
+    assert resp[0]['title'] == 'My step'

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -1,4 +1,5 @@
 import json
+from re import A
 
 import pytest
 import responses
@@ -7,7 +8,13 @@ import responses
 def get_tests(r):
     resp = [{'id': c, 'status_id': int(i)} for c, i in
             enumerate(r.params['status_id'].split(','), 1)]
-    return 200, {}, json.dumps(resp)
+    return 200, {}, json.dumps({
+        "offset": 0,
+        "limit": 250,
+        "size": len(resp),
+        "tests": resp
+        }
+    )
 
 
 def test_get_test(api, mock, url):
@@ -27,6 +34,17 @@ def test_get_tests(api, mock, url, status_id):
         url('get_tests/2'),
         get_tests
     )
-    resp = api.tests.get_tests(2, status_id=status_id)
+    resp = api.tests.get_tests(2, status_id=status_id).get('tests')
+    assert resp[0]['status_id'] == 1
+    assert resp[1]['status_id'] == 5
+
+@pytest.mark.parametrize('status_id', ('1,5', [1, 5]))
+def test_get_tests_bulk(api, mock, url, status_id):
+    mock.add_callback(
+        responses.GET,
+        url('get_tests/2'),
+        get_tests
+    )
+    resp = api.tests.get_tests_bulk(2, status_id=status_id)
     assert resp[0]['status_id'] == 1
     assert resp[1]['status_id'] == 5


### PR DESCRIPTION
Resolved #61 

Adding support for "bulk" endpoints as described in the documentation [here](https://support.gurock.com/hc/en-us/articles/7077083596436-Introduction-to-the-TestRail-API#01G68HCTTP60YD4P5Y032Y68D2)

Existing methods that support bulk endpoints are defined with `_bulk` appended to the method name.

Some current methods that seem to support offset and limits were missing from the constructors, so those were updated. Also, some unittests were not testing with the correct response object. These were also addressed to keep the testing between the bulk and regular methods consistent by fixing the callbacks.



