### PR TITLE
Fix move_cases_to_section

### DIFF
--- a/testrail_api/_category.py
+++ b/testrail_api/_category.py
@@ -492,18 +492,25 @@ class Cases(_MetaCategory):
             json={"case_ids": ",".join(map(str, case_ids))},
         )
 
-    def move_cases_to_section(self, section_or_suite_id: int, case_ids: List[str]):
+    def move_cases_to_section(
+        self, section_id: int, suite_id: int, case_ids: List[str]
+    ):
         """
         Moves cases to another suite or section.
 
-        :param section_or_suite_id: int
-            The ID of the section or suite the case will be moved to.
+        :param section_id: int
+            The ID of the section the cases will be moved to.
+        :param suite_id: int
+            The ID of the suite for the section the cases will be moved to.
         :param case_ids:
             List of case IDs.
         """
         return self.s.post(
-            endpoint=f"move_cases_to_section/{section_or_suite_id}",
-            json={"case_ids": ",".join(map(str, case_ids))},
+            endpoint=f"move_cases_to_section/{section_id}",
+            json={
+                "case_ids": ",".join(map(str, case_ids)),
+                "suite_id": suite_id,
+            },
         )
 
 

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -193,5 +193,6 @@ def test_move_cases_to_section(api, mock, url):
     mock.add_callback(
         responses.POST, url("move_cases_to_section/5"), lambda x: (200, {}, x.body)
     )
-    resp = api.cases.move_cases_to_section(section_or_suite_id=5, case_ids=[1, 2, 3])
+    resp = api.cases.move_cases_to_section(5, 6, case_ids=[1, 2, 3])
     assert resp["case_ids"] == "1,2,3"
+    assert resp["suite_id"] == 6


### PR DESCRIPTION
Per the documentation: https://support.gurock.com/hc/en-us/articles/7077292642580-Cases#movecasestosection

![image](https://user-images.githubusercontent.com/8107880/203176669-882dc7fb-e4d4-463c-bf0b-1e29dd138872.png)

Both suite and section ids are required.