### PR TITLE
made project id optional

### DIFF
--- a/testrail_api/_category.py
+++ b/testrail_api/_category.py
@@ -2160,7 +2160,9 @@ class Users(_MetaCategory):
             (Required for non-administrators. Requires TestRail 6.6 or later.)
         :return: response
         """
-        return self.s.get(endpoint=f"get_users/{project_id}" if project_id else "get_users")
+        return self.s.get(
+            endpoint=f"get_users/{project_id}" if project_id else "get_users"
+        )
 
 
 class SharedSteps(_MetaCategory):

--- a/testrail_api/_category.py
+++ b/testrail_api/_category.py
@@ -2152,7 +2152,7 @@ class Users(_MetaCategory):
         """
         return self.s.get(endpoint="get_user_by_email", params={"email": email})
 
-    def get_users(self, project_id: int) -> List[dict]:
+    def get_users(self, project_id: Optional[int] = None) -> List[dict]:
         """
         Returns a list of users.
         :param project_id:
@@ -2160,7 +2160,7 @@ class Users(_MetaCategory):
             (Required for non-administrators. Requires TestRail 6.6 or later.)
         :return: response
         """
-        return self.s.get(endpoint=f"get_users/{project_id}")
+        return self.s.get(endpoint=f"get_users/{project_id}" if project_id else "get_users")
 
 
 class SharedSteps(_MetaCategory):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -41,6 +41,18 @@ def test_get_users(api, mock, url):
     response = api.users.get_users(15)
     assert response[0]['name'] == 'John Smith'
 
+def test_get_users_no_project_id(api, mock, url):
+    mock.add_callback(
+        responses.GET,
+        url('get_users'),
+        lambda x: (
+            200, {}, json.dumps([{'email': 'testrail@ff.com', 'id': 1,
+                                  'name': 'John Smith', 'is_active': True}])
+        ),
+    )
+    response = api.users.get_users()
+    assert response[0]['name'] == 'John Smith'
+
 
 def test_get_current_user(api, mock, url):
     mock.add_callback(


### PR DESCRIPTION
admin accounts are allowed to query users without a project id. This change reflects that ability.