### PR TITLE
chore: add bulk methods for get_suites and get_users

### DIFF
--- a/testrail_api/_category.py
+++ b/testrail_api/_category.py
@@ -1970,6 +1970,22 @@ class Suites(_MetaCategory):
         """
         return self.s.get(endpoint=f"get_suites/{project_id}", params=self._opt({"offset": offset, "limit": limit}))
 
+    def get_suites_bulk(self, project_id: int, **kwargs) -> list[dict]:
+        """
+        Return a list of test suites for a project with pagination.
+
+        :param project_id:
+            The ID of the project
+        :param kwargs:
+            :key offset: int
+                Where to start counting the suites from (the offset)
+            :key limit: int
+                The number of suites the response should return
+        :return: List of test suites
+        :returns: list[dict]
+        """
+        return _bulk_api_method(self.get_suites, "suites", project_id, **kwargs)
+
     def add_suite(self, project_id: int, name: str, **kwargs) -> dict:
         """
         Creates a new test suite.
@@ -2142,6 +2158,23 @@ class Users(_MetaCategory):
             endpoint=f"get_users/{project_id}" if project_id else "get_users",
             params=self._opt({"offset": offset, "limit": limit}),
         )
+
+    def get_users_bulk(self, project_id: Optional[int] = None, **kwargs) -> list[dict]:
+        """
+        Return a list of users with pagination.
+
+        :param project_id:
+            The ID of the project for which you would like to retrieve user information.
+            (Required for non-administrators. Requires TestRail 6.6 or later.)
+        :param kwargs:
+            :key offset: int
+                Where to start counting the users from (the offset)
+            :key limit: int
+                The number of users the response should return
+        :return: List of users
+        :returns: list[dict]
+        """
+        return _bulk_api_method(self.get_users, "users", project_id, **kwargs)
 
 
 class SharedSteps(_MetaCategory):

--- a/tests/test_suites.py
+++ b/tests/test_suites.py
@@ -45,6 +45,13 @@ def test_get_suites(api, mock, url, offset, limit):
     assert resp["suites"][1]["description"] == "Suite2"
 
 
+def test_get_suites_bulk(api, mock, url):
+    mock.add_callback(responses.GET, url("get_suites/5"), get_suites)
+    resp = api.suites.get_suites_bulk(5)
+    assert resp[0]["id"] == 1
+    assert resp[1]["description"] == "Suite2"
+
+
 def test_add_suite(api, mock, url):
     mock.add_callback(responses.POST, url("add_suite/7"), add_suite)
     resp = api.suites.add_suite(7, "New suite", description="My new suite")

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -61,6 +61,20 @@ def test_get_users_no_project_id(api, mock, url, offset, limit):
     assert response["users"][0]["name"] == "John Smith"
 
 
+def test_get_users_bulk(api, mock, url):
+    mock.add_callback(responses.GET, url("get_users/15"), get_users)
+    resp = api.users.get_users_bulk(15)
+    assert resp[0]["id"] == 1
+    assert resp[1]["name"] == "Jane Smith"
+
+
+def test_get_users_bulk_no_project_id(api, mock, url):
+    mock.add_callback(responses.GET, url("get_users"), get_users)
+    resp = api.users.get_users_bulk()
+    assert resp[0]["id"] == 1
+    assert resp[1]["name"] == "Jane Smith"
+
+
 def test_get_current_user(api, mock, url):
     mock.add_callback(
         responses.GET,


### PR DESCRIPTION
### Bulk API method additions

* Added a `get_suites_bulk` method to the `Suites` category to allow paginated retrieval of test suites for a given project using the shared `_bulk_api_method` utility.
* Added a `get_users_bulk` method to the `Users` category to allow paginated retrieval of users, supporting both project-specific and global queries, also via `_bulk_api_method`.

### Test coverage

* Added `test_get_suites_bulk` in `tests/test_suites.py` to verify the new `get_suites_bulk` functionality.
* Added `test_get_users_bulk` and `test_get_users_bulk_no_project_id` in `tests/test_users.py` to verify `get_users_bulk` with and without a project ID.