### PR TITLE
Harden session, bulk pagination, exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,8 +134,9 @@ QWEN.md
 .github/copilot/
 .github/copilot-instructions.md
 
-# API documentation reference (local only)
+# API documentation reference and improvement analysis (local only)
 api_docs/
+api_dics/
 
 # Other
 TODO.txt

--- a/testrail_api/_category.py
+++ b/testrail_api/_category.py
@@ -6,24 +6,31 @@ from pathlib import Path
 from typing import Any
 
 from ._enums import METHODS
+from ._exception import TestRailAPIError
 from ._session import Session
 
-OFFSET_MAX = 250
 LIMIT_MAX = 250
 
 
 def _bulk_api_method(func: Callable, resp_key: str, *args, **kwargs) -> list:
     """
-    Get the objects handling the pagination via offset.
+    Get all the objects handling the pagination via offset.
 
-    If the size returned from the API is less than the offset value.
+    Stops when the API returns a page shorter than the page size.
     """
-    _response_objects = []
-    for offset in itertools.count(0, OFFSET_MAX):
-        kwargs.update({"offset": offset, "limit": LIMIT_MAX})
-        _resp = func(*args, **kwargs)
-        _response_objects.extend(_resp.get(resp_key))
-        if _resp.get("size") < LIMIT_MAX:
+    if "limit" in kwargs or "offset" in kwargs:
+        raise TypeError("limit and offset are managed automatically by *_bulk methods, use the regular method instead")
+    _response_objects: list = []
+    for offset in itertools.count(0, LIMIT_MAX):
+        _resp = func(*args, **kwargs, offset=offset, limit=LIMIT_MAX)
+        if not isinstance(_resp, dict) or resp_key not in _resp:
+            raise TestRailAPIError(
+                f"Expected a paginated response with the {resp_key!r} key, got {type(_resp).__name__}. "
+                "Bulk methods require TestRail 6.7+ pagination and a response handler returning the parsed JSON."
+            )
+        _page = _resp[resp_key] or []
+        _response_objects.extend(_page)
+        if len(_page) < LIMIT_MAX:
             break
     return _response_objects
 
@@ -153,7 +160,7 @@ class Attachments(_MetaCategory):
             params={"limit": limit, "offset": offset},
         )
 
-    def get_attachments_for_plan(self, plan_id: int, limit: int = 250, offset: int = 0) -> list[dict]:
+    def get_attachments_for_plan(self, plan_id: int, limit: int = 250, offset: int = 0) -> dict:
         """
         Returns a list of attachments for a test plan.
 
@@ -174,7 +181,7 @@ class Attachments(_MetaCategory):
             params={"limit": limit, "offset": offset},
         )
 
-    def get_attachments_for_plan_entry(self, plan_id: int, entry_id: int, **kwargs) -> list[dict]:
+    def get_attachments_for_plan_entry(self, plan_id: int, entry_id: int, **kwargs) -> dict:
         """
         Returns a list of attachments for a test plan entry.
 
@@ -194,7 +201,7 @@ class Attachments(_MetaCategory):
             params=kwargs,
         )
 
-    def get_attachments_for_run(self, run_id: int, limit: int = 250, offset: int = 0) -> list[dict]:
+    def get_attachments_for_run(self, run_id: int, limit: int = 250, offset: int = 0) -> dict:
         """
         Returns a list of attachments for a test run.
 
@@ -215,7 +222,7 @@ class Attachments(_MetaCategory):
             params={"limit": limit, "offset": offset},
         )
 
-    def get_attachments_for_test(self, test_id: int, **kwargs) -> list[dict]:
+    def get_attachments_for_test(self, test_id: int, **kwargs) -> dict:
         """
         Returns a list of attachments for test results.
 
@@ -416,7 +423,7 @@ class Cases(_MetaCategory):
         """
         return self.s.get(endpoint=f"get_cases/{project_id}", params=kwargs)
 
-    def get_history_for_case(self, case_id: int, limit: int = 250, offset: int = 0) -> list[dict]:
+    def get_history_for_case(self, case_id: int, limit: int = 250, offset: int = 0) -> dict:
         """
         Returns the edit history for a test case_id.
 
@@ -586,7 +593,7 @@ class Cases(_MetaCategory):
         case_ids: list[int],
         suite_id: int | None = None,
         soft: int = 0,
-    ) -> None:
+    ) -> dict | None:
         """
         Deletes multiple test cases from a project or test suite.
 
@@ -622,7 +629,7 @@ class Cases(_MetaCategory):
             json={"case_ids": ",".join(map(str, case_ids))},
         )
 
-    def move_cases_to_section(self, section_id: int, suite_id: int, case_ids: list[str]) -> dict:
+    def move_cases_to_section(self, section_id: int, suite_id: int, case_ids: list[int]) -> dict:
         """
         Moves cases to another suite or section.
 
@@ -643,51 +650,13 @@ class Cases(_MetaCategory):
 
     def get_cases_bulk(self, project_id: int, **kwargs) -> list[dict]:
         """
-        Return a list of test cases for a project or specific test suite with pagination.
+        Return all test cases for a project or test suite, transparently handling pagination.
+
+        Accepts the same filters as ``get_cases`` except ``limit``/``offset``,
+        which are managed automatically.
 
         :param project_id:
             The ID of the project
-        :param kwargs:
-            :key suite_id: int
-                The ID of the test suite (optional if the project is operating in
-                single suite mode)
-            :key created_after: int/datetime
-                Only return test cases created after this date (as UNIX timestamp).
-            :key created_before: int/datetime
-                Only return test cases created before this date (as UNIX timestamp).
-            :key created_by: list[int] or comma-separated string
-                A comma-separated list of creators (user IDs) to filter by.
-            :key filter: str
-                Only return cases with matching filter string in the case title
-            :key limit: int
-                The number of test cases the response should return
-                (The response size is 250 by default) (requires TestRail 6.7 or later)
-            :key milestone_id: list[int] or comma-separated string
-                A comma-separated list of milestone IDs to filter by (not available
-                if the milestone field is disabled for the project).
-            :key offset: int
-                Where to start counting the tests cases from (the offset)
-                (requires TestRail 6.7 or later)
-            :key priority_id: list[int] or comma-separated string
-                A comma-separated list of priority IDs to filter by.
-            :key refs: str
-                A single Reference ID (e.g. TR-1, 4291, etc.)
-                (requires TestRail 6.5.2 or later)
-            :key section_id: int
-                The ID of a test case section
-            :key template_id: list[int] or comma-separated string
-                A comma-separated list of template IDs to filter by
-                (requires TestRail 5.2 or later)
-            :key type_id: list[int] or comma-separated string
-                A comma-separated list of case type IDs to filter by.
-            :key updated_after: int/datetime
-                Only return test cases updated after this date (as UNIX timestamp).
-            :key updated_before: int/datetime
-                Only return test cases updated before this date (as UNIX timestamp).
-            :key updated_by: list[int] or comma-separated string
-                A comma-separated list of user IDs who updated test cases to filter by.
-            :key label_id: list[int] or comma-separated string
-                A comma-separated list of label IDs to filter by.
         :return: List of test cases
         :returns: list[dict]
         """
@@ -964,20 +933,15 @@ class Milestones(_MetaCategory):
 
     def get_milestones_bulk(self, project_id: int, **kwargs) -> list[dict]:
         """
-        Return a list of milestones for a project handling pagination.
+        Return all milestones for a project, transparently handling pagination.
+
+        Accepts the same filters as ``get_milestones`` except ``limit``/``offset``,
+        which are managed automatically.
 
         :param project_id:
             The ID of the project
-        :param kwargs:
-            :key is_completed: int/bool
-                1/True to return completed milestones only.
-                0/False to return open (active/upcoming) milestones only
-                (available since TestRail 4.0).
-            :key is_started: int/bool
-                1/True to return started milestones only.
-                0/False to return upcoming milestones only
-                            (available since TestRail 5.3).
-        :return: response
+        :return: List of milestones
+        :returns: list[dict]
         """
         return _bulk_api_method(self.get_milestones, "milestones", project_id, **kwargs)
 
@@ -1259,15 +1223,15 @@ class Plans(_MetaCategory):
 
     def get_plans_bulk(self, project_id: int, **kwargs) -> list[dict]:
         """
-        Return a list of test plans for a project handling pagination.
+        Return all test plans for a project, transparently handling pagination.
+
+        Accepts the same filters as ``get_plans`` except ``limit``/``offset``,
+        which are managed automatically.
 
         :param project_id:
             The ID of the project
-        :param kwargs:
-            :key is_completed: int
-                True for returning completed test plans and false for uncompleted
-                test plans
-        :return: response
+        :return: List of test plans
+        :returns: list[dict]
         """
         return _bulk_api_method(self.get_plans, "plans", project_id, **kwargs)
 
@@ -1523,7 +1487,7 @@ class Results(_MetaCategory):
             params=dict(limit=limit, offset=offset, **kwargs),
         )
 
-    def add_result(self, test_id: int, **kwargs) -> list[dict]:
+    def add_result(self, test_id: int, **kwargs) -> dict:
         """
         Adds a new test result, comment or assigns a test.
 
@@ -1705,15 +1669,13 @@ class Results(_MetaCategory):
 
     def get_results_bulk(self, test_id: int, **kwargs) -> list[dict]:
         """
-        Return a list of test results for a test run handling pagination.
+        Return all test results for a test, transparently handling pagination.
+
+        Accepts the same filters as ``get_results`` except ``limit``/``offset``,
+        which are managed automatically.
 
         :param test_id:
-            The ID of the test run
-        :param kwargs: filters
-            :key defects_filter: str
-                A single Defect ID (e.g. TR-1, 4291, etc.)
-            :key status_id: list[int] or comma-separated string
-                A comma-separated list of status IDs to filter by.
+            The ID of the test
         :return: List of results
         :returns: list[dict]
         """
@@ -1721,43 +1683,30 @@ class Results(_MetaCategory):
 
     def get_results_for_case_bulk(self, run_id: int, case_id: int, **kwargs) -> list[dict]:
         """
-        Return a list of test results for a case in a test run handling pagination.
+        Return all test results for a case in a test run, transparently handling pagination.
 
-        For the difference between get_results vs get_results_for_case, please see
-        the documentation for get_results_for_case.
+        Accepts the same filters as ``get_results_for_case`` except ``limit``/``offset``,
+        which are managed automatically.
 
         :param run_id:
             The ID of the test run
         :param case_id:
             The ID of the test case
-        :param kwargs: filters
-            :key defects_filter: str
-                A single Defect ID (e.g. TR-1, 4291, etc.)
-            :key status_id: list[int] or comma-separated string
-                A comma-separated list of status IDs to filter by.
-        :return: response
+        :return: List of results
         :returns: list[dict]
         """
         return _bulk_api_method(self.get_results_for_case, "results", run_id, case_id, **kwargs)
 
     def get_results_for_run_bulk(self, run_id: int, **kwargs) -> list[dict]:
         """
-        Returns a list of test results for a test run handling pagination.
+        Return all test results for a test run, transparently handling pagination.
+
+        Accepts the same filters as ``get_results_for_run`` except ``limit``/``offset``,
+        which are managed automatically.
 
         :param run_id:
             The ID of the test run
-        :param kwargs: filters
-            :key created_after: int/datetime
-                Only return test results created after this date.
-            :key created_before: int/datetime
-                Only return test results created before this date.
-            :key created_by: list[int] or comma-separated string
-                A comma-separated list of creators (user IDs) to filter by.
-            :key defects_filter: str
-                A single Defect ID (e.g. TR-1, 4291, etc.)
-            :key status_id: list[int] or comma-separated string
-                A comma-separated list of status IDs to filter by.
-        :return: response
+        :return: List of results
         :returns: list[dict]
         """
         return _bulk_api_method(self.get_results_for_run, "results", run_id, **kwargs)
@@ -1930,32 +1879,14 @@ class Runs(_MetaCategory):
 
     def get_runs_bulk(self, project_id: int, **kwargs) -> list[dict]:
         """
-        Returns a list of test runs for a project.
+        Return all test runs for a project, transparently handling pagination.
 
         Only returns those test runs that are not part of a test plan (please see get_plans/get_plan for this).
+        Accepts the same filters as ``get_runs`` except ``limit``/``offset``,
+        which are managed automatically.
 
         :param project_id: int
             The ID of the project
-        :param kwargs: filters
-            :key created_after: int/datetime
-                Only return test runs created after this date (as UNIX timestamp).
-            :key created_before: int/datetime
-                Only return test runs created before this date (as UNIX timestamp).
-            :key created_by: list[int] or comma-separated string
-                A comma-separated list of creators (user IDs) to filter by.
-            :key include_plan_runs: int/bool
-                1/True to also return runs that are part of a test plan.
-                Only applied together with the is_completed filter
-                (requires TestRail 6.7 or later).
-            :key is_completed: int/bool
-                1/True to return completed test runs only.
-                0/False to return active test runs only.
-            :key milestone_id: list[int] or comma-separated string
-                A comma-separated list of milestone IDs to filter by.
-            :key refs_filter: str
-                A single Reference ID (e.g. TR-a, 4291, etc.)
-            :key suite_id: list[int] or comma-separated string
-                A comma-separated list of test suite IDs to filter by.
         :return: List of runs
         :returns: list[dict]
         """
@@ -2054,7 +1985,7 @@ class Sections(_MetaCategory):
         """
         return self.s.post(endpoint=f"update_section/{section_id}", json=kwargs)
 
-    def delete_section(self, section_id: int, soft: int = 0) -> None:
+    def delete_section(self, section_id: int, soft: int = 0) -> dict | None:
         """
         Deletes an existing section.
 
@@ -2072,14 +2003,13 @@ class Sections(_MetaCategory):
 
     def get_sections_bulk(self, project_id: int, **kwargs) -> list[dict]:
         """
-        Returns a list of sections for a project and/or test suite handling pagination.
+        Return all sections for a project and/or test suite, transparently handling pagination.
+
+        Accepts the same arguments as ``get_sections`` except ``limit``/``offset``,
+        which are managed automatically.
 
         :param project_id:
             The ID of the project
-        :param kwargs:
-            :key suite_id:
-                The ID of the test suite (optional if the project is operating in
-                single suite mode)
         :return: List of sections
         :returns: list[dict]
         """
@@ -2135,15 +2065,12 @@ class Suites(_MetaCategory):
 
     def get_suites_bulk(self, project_id: int, **kwargs) -> list[dict]:
         """
-        Return a list of test suites for a project with pagination.
+        Return all test suites for a project, transparently handling pagination.
+
+        ``limit``/``offset`` are managed automatically.
 
         :param project_id:
             The ID of the project
-        :param kwargs:
-            :key offset: int
-                Where to start counting the suites from (the offset)
-            :key limit: int
-                The number of suites the response should return
         :return: List of test suites
         :returns: list[dict]
         """
@@ -2181,7 +2108,7 @@ class Suites(_MetaCategory):
         """
         return self.s.post(endpoint=f"update_suite/{suite_id}", json=kwargs)
 
-    def delete_suite(self, suite_id: int, soft: int = 0) -> None:
+    def delete_suite(self, suite_id: int, soft: int = 0) -> dict | None:
         """
         Deletes an existing test suite.
 
@@ -2256,7 +2183,7 @@ class Tests(_MetaCategory):
             params=dict(limit=limit, offset=offset, **kwargs),
         )
 
-    def update_test(self, test_id: int, labels: list) -> dict:
+    def update_test(self, test_id: int, labels: list[int | str]) -> dict:
         """
         Updates the labels assigned to an existing test.
 
@@ -2268,7 +2195,7 @@ class Tests(_MetaCategory):
         """
         return self.s.post(endpoint=f"update_test/{test_id}", json={"labels": labels})
 
-    def update_tests(self, test_ids: list, labels: list) -> dict:
+    def update_tests(self, test_ids: list[int], labels: list[int | str]) -> dict:
         """
         Updates the labels assigned to multiple tests with the same values.
 
@@ -2282,15 +2209,13 @@ class Tests(_MetaCategory):
 
     def get_tests_bulk(self, run_id: int, **kwargs) -> list[dict]:
         """
-        Returns a list of tests for a test run handling pagination.
+        Return all tests for a test run, transparently handling pagination.
+
+        Accepts the same filters as ``get_tests`` except ``limit``/``offset``,
+        which are managed automatically.
 
         :param run_id:
             The ID of the test run
-        :param kwargs:
-            :key status_id: list[str] or comma-separated string
-                A comma-separated list of status IDs to filter by.
-            :key label_id: list[int] or comma-separated string
-                A comma-separated list of label IDs to filter by.
         :return: List of tests
         :returns: list[dict]
         """
@@ -2412,16 +2337,13 @@ class Users(_MetaCategory):
 
     def get_users_bulk(self, project_id: int | None = None, **kwargs) -> list[dict]:
         """
-        Return a list of users with pagination.
+        Return all users, transparently handling pagination.
+
+        ``limit``/``offset`` are managed automatically.
 
         :param project_id:
             The ID of the project for which you would like to retrieve user information.
             (Required for non-administrators. Requires TestRail 6.6 or later.)
-        :param kwargs:
-            :key offset: int
-                Where to start counting the users from (the offset)
-            :key limit: int
-                The number of users the response should return
         :return: List of users
         :returns: list[dict]
         """
@@ -2535,23 +2457,13 @@ class SharedSteps(_MetaCategory):
 
     def get_shared_steps_bulk(self, project_id: int, **kwargs) -> list[dict]:
         """
-        Returns a list of shared steps for a project.
+        Return all shared steps for a project, transparently handling pagination.
+
+        Accepts the same filters as ``get_shared_steps`` except ``limit``/``offset``,
+        which are managed automatically.
 
         :param project_id: int
             The ID of the project.
-        :param kwargs:
-            :key created_after: int or datetime
-                Only return shared steps created after this date
-            :key created_before: int or datetime
-                Only return shared steps created before this date
-            :key created_by: list[int] or A comma-separated str
-                A comma-separated list of creators (user IDs) to filter by.
-            :key updated_after: int or datetime
-                Only return shared steps updated after this date
-            :key updated_before: int or datetime
-                Only return shared steps updated before this date
-            :key refs: str
-                A single Reference ID (e.g. TR-a, 4291, etc.)
         :return: List of shared steps
         :returns: list[dict]
         """

--- a/testrail_api/_exception.py
+++ b/testrail_api/_exception.py
@@ -1,5 +1,10 @@
 """Exceptions."""
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import requests
+
 
 class TestRailError(Exception):
     """Base Exception."""
@@ -10,4 +15,25 @@ class TestRailAPIError(TestRailError):
 
 
 class StatusCodeError(TestRailAPIError):
-    """Status code Exception."""
+    """
+    Raised when the API responds with a non-OK HTTP status code.
+
+    The positional args keep the historical layout
+    ``(status_code, reason, url, content)``, and the same values are also
+    available as attributes, together with the full ``requests.Response``.
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        reason: str,
+        url: str,
+        content: bytes,
+        response: "requests.Response | None" = None,
+    ) -> None:
+        super().__init__(status_code, reason, url, content)
+        self.status_code = status_code
+        self.reason = reason
+        self.url = url
+        self.content = content
+        self.response = response

--- a/testrail_api/_session.py
+++ b/testrail_api/_session.py
@@ -3,8 +3,9 @@
 import logging
 import time
 import warnings
-from collections.abc import Callable
-from datetime import datetime
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from json.decoder import JSONDecodeError
 from os import environ
 from pathlib import Path
@@ -20,6 +21,12 @@ from ._exception import StatusCodeError, TestRailError
 logger = logging.getLogger(__package__)
 
 RATE_LIMIT_STATUS_CODE: Final[int] = 429
+MAX_RATE_LIMIT_DELAY: Final[float] = 300.0
+DOWNLOAD_CHUNK_SIZE: Final[int] = 2**20
+
+_SENSITIVE_HEADERS: Final[frozenset[str]] = frozenset(
+    {"authorization", "proxy-authorization", "cookie", "set-cookie", "x-api-key"},
+)
 
 _S = TypeVar("_S", bound="Session")
 
@@ -41,13 +48,18 @@ class Session:
         email: str | None = None,
         password: str | None = None,
         *,
-        exc: bool = False,
+        timeout: float | tuple[float, float] = 30,
+        verify: bool | str = True,
+        headers: dict[str, str] | None = None,
+        retry: float = 3,
+        exc_iterations: int = 3,
+        raise_on_error: bool | None = None,
+        exc: bool | None = None,
         rate_limit: bool = True,
         warn_ignore: bool = False,
         retry_exceptions: tuple[type[BaseException], ...] = (),
         response_handler: Callable[[requests.Response], Any] | None = None,
         session: requests.Session | None = None,
-        **kwargs,
     ) -> None:
         """
         Session constructor.
@@ -58,28 +70,33 @@ class Session:
             Email for the account on the TestRail.
         :param password:
             Password for the account on the TestRail or token.
-        :param session:
-            A Given session will be used instead of new one.
+        :param timeout:
+            How many seconds to wait for the server to send data (default: 30).
+            May be a ``(connect, read)`` tuple.
+        :param verify:
+            Controls whether we verify the server's certificate (default: True).
+        :param headers:
+            Dictionary of HTTP headers to send with every request.
+        :param retry:
+            Delay in seconds between retries on HTTP 429 when the response
+            has no valid retry-after header (default: 3).
+        :param exc_iterations:
+            Number of attempts for rate-limit and ``retry_exceptions`` retries (default: 3).
+        :param raise_on_error:
+            Raise :class:`StatusCodeError` for non-OK responses (default: True).
         :param exc:
-            Catching exceptions.
+            Deprecated, use ``raise_on_error`` (note the inverted meaning:
+            ``exc=True`` matches ``raise_on_error=False``).
         :param rate_limit:
-            Check the response header for the rate limit and retry the request.
+            Check the response for HTTP 429 and retry the request.
         :param warn_ignore:
             Ignore warning when not using HTTPS.
         :param retry_exceptions:
             Set of exceptions to retry the request.
         :param response_handler:
             Override default response handling.
-        :param kwargs:
-            :key timeout: int (default: 30)
-                How many seconds to wait for the server to send data.
-            :key verify: bool (default: True)
-                Controls whether we verify the server's certificate.
-            :key headers: dict
-                Dictionary of HTTP Headers to send.
-            :key retry: int (default 3)
-                Delay in receiving code 429.
-            :key exc_iterations: int (default 3)
+        :param session:
+            A Given session will be used instead of new one.
         """
         _url = self.__require(url, Environ.URL, "Url").rstrip("/")
         if _url.startswith("http://") and not warn_ignore:
@@ -89,28 +106,37 @@ class Session:
         _email = self.__require(email, Environ.EMAIL, "Email")
         _password = self.__require(password, Environ.PASSWORD, "Password")
         self.__base_url = f"{_url}/index.php?/api/v2/"
-        self.__timeout = kwargs.get("timeout", 30)
+        self.__timeout = timeout
         self.__session = session or requests.Session()
         self.__session.headers["User-Agent"] = self._user_agent
-        self.__session.headers.update(kwargs.get("headers", {}))
-        self.__session.verify = kwargs.get("verify", True)
-        self.__retry = kwargs.get("retry", 3)
+        self.__session.headers.update(headers or {})
+        self.__session.verify = verify
+        self.__retry = retry
         self.__user_email = _email
         self.__session.auth = (self.__user_email, _password)
-        self.__exc = exc
-        self.__retry_exceptions = (KeyError, *retry_exceptions)
-        self.__exc_iterations = kwargs.get("exc_iterations", 3)
+        if exc is not None:
+            warnings.warn(
+                "The 'exc' argument is deprecated, use 'raise_on_error' instead "
+                "(note the inverted meaning: exc=True matches raise_on_error=False)",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if raise_on_error is None:
+            raise_on_error = True if exc is None else not exc
+        self.__raise_on_error = raise_on_error
+        self.__retry_exceptions = tuple(retry_exceptions)
+        self.__exc_iterations = exc_iterations
         self.__response_handler = response_handler or self.__default_response_handler
         self._rate_limit = rate_limit
         logger.info(
             "Create Session{url: %s, user: %s, timeout: %s, headers: %s, verify: "
-            "%s, exception: %s, exc_iterations: %s, retry: %s}",
+            "%s, raise_on_error: %s, exc_iterations: %s, retry: %s}",
             _url,
             self.__user_email,
             self.__timeout,
-            self.__session.headers,
+            self._redact_headers(self.__session.headers),
             self.__session.verify,
-            self.__exc,
+            self.__raise_on_error,
             self.__exc_iterations,
             self.__retry,
         )
@@ -144,6 +170,11 @@ class Session:
             raise TestRailError(f"{name} is not set. Use argument {name.lower()} or env {env_var}")
         return result
 
+    @staticmethod
+    def _redact_headers(headers: Mapping[str, Any]) -> dict[str, Any]:
+        """Replace values of sensitive headers so they can be logged safely."""
+        return {key: "***" if key.lower() in _SENSITIVE_HEADERS else value for key, value in headers.items()}
+
     def __default_response_handler(self, response: requests.Response) -> Any:
         """Deserialization json or return None."""
         if not response.ok:
@@ -154,12 +185,13 @@ class Session:
                 response.url,
                 response.content,
             )
-            if not self.__exc:
+            if self.__raise_on_error:
                 raise StatusCodeError(
                     response.status_code,
                     response.reason,
                     response.url,
                     response.content,
+                    response=response,
                 )
         logger.debug("Response body: %s", response.text)
         try:
@@ -168,26 +200,51 @@ class Session:
             return response.text or None
 
     @staticmethod
-    def __get_converter(params: dict) -> None:
-        """Convert GET parameters."""
+    def __get_converter(params: dict) -> dict:
+        """Convert GET parameters, returning a new dict."""
+        converted = {}
         for key, value in params.items():
-            if isinstance(value, (list, tuple, set)):
-                # Converting a list to a string '1,2,3'
-                params[key] = ",".join(str(i) for i in value)
-            elif isinstance(value, bool):
+            if isinstance(value, bool):
                 # Converting a boolean value to integer
-                params[key] = int(value)
+                converted[key] = int(value)
+            elif isinstance(value, (list, tuple, set)):
+                # Converting a collection to a string '1,2,3' (sets are sorted for determinism)
+                items = sorted(value, key=str) if isinstance(value, set) else value
+                converted[key] = ",".join(str(i) for i in items)
             elif isinstance(value, datetime):
                 # Converting a datetime value to integer (UNIX timestamp)
-                params[key] = round(value.timestamp())
+                converted[key] = round(value.timestamp())
+            else:
+                converted[key] = value
+        return converted
+
+    @classmethod
+    def __post_converter(cls, json: Any) -> Any:
+        """Convert POST parameters recursively, returning a new structure."""
+        if isinstance(json, datetime):
+            # Converting a datetime value to integer (UNIX timestamp)
+            return round(json.timestamp())
+        if isinstance(json, dict):
+            return {key: cls.__post_converter(value) for key, value in json.items()}
+        if isinstance(json, (list, tuple)):
+            return [cls.__post_converter(value) for value in json]
+        return json
 
     @staticmethod
-    def __post_converter(json: dict) -> None:
-        """Convert POST parameters."""
-        for key, value in json.items():
-            if isinstance(value, datetime):
-                # Converting a datetime value to integer (UNIX timestamp)
-                json[key] = round(value.timestamp())
+    def _parse_retry_after(value: str) -> float | None:
+        """Parse a retry-after header: either a number of seconds or an HTTP-date."""
+        value = value.strip()
+        if not value:
+            return None
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        try:
+            date = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+        return (date - datetime.now(timezone.utc)).total_seconds()
 
     def get(self, endpoint: str, params: dict[Any, Any] | None = None) -> Any:
         """GET method."""
@@ -218,8 +275,10 @@ class Session:
             headers = kwargs.setdefault("headers", {})
             headers.update({"Content-Type": "application/json"})
 
-        self.__get_converter(kwargs.get("params", {}))
-        self.__post_converter(kwargs.get("json", {}))
+        if "params" in kwargs:
+            kwargs["params"] = self.__get_converter(kwargs["params"])
+        if "json" in kwargs:
+            kwargs["json"] = self.__post_converter(kwargs["json"])
 
         for count in range(self.__exc_iterations):
             try:
@@ -237,8 +296,9 @@ class Session:
                 and response.status_code == RATE_LIMIT_STATUS_CODE
                 and count < self.__exc_iterations - 1
             ):
-                retry_after = response.headers.get("retry-after", "")
-                delay = int(retry_after) if retry_after.strip().isdigit() else self.__retry
+                retry_after = self._parse_retry_after(response.headers.get("retry-after", ""))
+                delay = self.__retry if retry_after is None else retry_after
+                delay = min(max(delay, 0.0), MAX_RATE_LIMIT_DELAY)
                 logger.warning(
                     "Rate limit (429) on %s, sleeping %s sec before retry %s/%s",
                     url,
@@ -265,9 +325,13 @@ class Session:
     def get_attachment(self, method: METHODS, src: str, file: Path | str, **kwargs) -> Path:
         """Download attach."""
         file = self._path(file)
-        response = self.request(method, src, raw=True, **kwargs)
-        if response.ok:
-            with file.open("wb") as attachment:
-                attachment.write(response.content)
-            return file
-        return self.__default_response_handler(response)
+        response = self.request(method, src, raw=True, stream=True, **kwargs)
+        try:
+            if response.ok:
+                with file.open("wb") as attachment:
+                    for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                        attachment.write(chunk)
+                return file
+            return self.__response_handler(response)
+        finally:
+            response.close()

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -217,8 +217,6 @@ def test_get_cases_bulk(api, mock, url):
         1,
         suite_id=2,
         section_id=3,
-        limit=5,
-        offset=10,
         created_after=now,
         created_before=round(now.timestamp()),
         updated_after=now,

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1,15 +1,19 @@
 import json
 import time
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 import responses
-from requests import Session
+from requests import Response, Session
 from requests.exceptions import ConnectionError
 
 from testrail_api import StatusCodeError
 from testrail_api import TestRailAPI as TRApi
 from testrail_api._category import _bulk_api_method
+from testrail_api._exception import TestRailAPIError as TRApiError
 from testrail_api._exception import TestRailError as TRError
 
 
@@ -77,7 +81,7 @@ def test_raise_rate_limit(api, mock, url):
 
 
 def test_exc_raise_rate_limit(auth_data, mock, url):
-    api = TRApi(*auth_data, exc=True)
+    api = TRApi(*auth_data, raise_on_error=False)
     mock.add_callback(
         responses.GET,
         url("get_case/1"),
@@ -88,7 +92,7 @@ def test_exc_raise_rate_limit(auth_data, mock, url):
 
 
 def test_exc_raise(auth_data, mock, url):
-    api = TRApi(*auth_data, exc=True)
+    api = TRApi(*auth_data, raise_on_error=False)
     mock.add_callback(
         responses.GET,
         url("get_case/1"),
@@ -99,7 +103,7 @@ def test_exc_raise(auth_data, mock, url):
 
 
 def test_raise(auth_data, mock, url):
-    api = TRApi(*auth_data, exc=False)
+    api = TRApi(*auth_data)
     mock.add_callback(
         responses.GET,
         url("get_case/1"),
@@ -110,35 +114,35 @@ def test_raise(auth_data, mock, url):
 
 
 def test_custom_exception_fails(auth_data, mock, url):
-    api = TRApi(*auth_data, exc=True, retry_exceptions=(CustomException,))
+    api = TRApi(*auth_data, raise_on_error=False, retry_exceptions=(CustomException,))
     mock.add_callback(responses.GET, url("get_case/1"), CustomExceptionRetry(fail=True))
     with pytest.raises(CustomException):
         api.cases.get_case(1)
 
 
 def test_custom_exception_succeeds(auth_data, mock, url):
-    api = TRApi(*auth_data, exc=True, retry_exceptions=(CustomException,))
+    api = TRApi(*auth_data, raise_on_error=False, retry_exceptions=(CustomException,))
     mock.add_callback(responses.GET, url("get_case/1"), CustomExceptionRetry(fail=False))
     response = api.cases.get_case(1)
     assert response.get("count") == 3
 
 
 def test_custom_exception_fails_different_exception(auth_data, mock, url):
-    api = TRApi(*auth_data, exc=True, retry_exceptions=(KeyboardInterrupt,))
+    api = TRApi(*auth_data, raise_on_error=False, retry_exceptions=(KeyboardInterrupt,))
     mock.add_callback(responses.GET, url("get_case/1"), CustomExceptionRetry(fail=True))
     with pytest.raises(CustomException):
         api.cases.get_case(1)
 
 
 def test_no_response_raise():
-    api = TRApi("https://asdadadsa.cd", "asd@asd.com", "asdasda", exc=False)
+    api = TRApi("https://asdadadsa.cd", "asd@asd.com", "asdasda")
     with pytest.raises(ConnectionError):
         api.cases.get_case(1)
 
 
 def test_get_email():
     email = "asd@asd.com"
-    api = TRApi("https://asdadadsa.cd", "asd@asd.com", "asdasda", exc=False)
+    api = TRApi("https://asdadadsa.cd", "asd@asd.com", "asdasda")
     assert api.user_email == email
 
 
@@ -164,7 +168,7 @@ def test_environment_variables(mock, url):
 
 def test_http_warn():
     with pytest.warns(UserWarning):
-        TRApi("http://asdadadsa.cd", "asd@asd.com", "asdasda", exc=False)
+        TRApi("http://asdadadsa.cd", "asd@asd.com", "asdasda")
 
 
 @pytest.mark.filterwarnings("error")
@@ -260,10 +264,157 @@ def test_close_method(auth_data):
 
 
 def test_request_return_none_with_zero_iterations():
-    # Initialize session with 0 iterations so the loop at line 218 never runs
-    api = TRApi("https://testrail.com", "user", "password", exc_iterations=0, exc=False)
+    # Initialize session with 0 iterations so the request loop never runs
+    api = TRApi("https://testrail.com", "user", "password", exc_iterations=0)
 
     # Call request - it should skip the loop and return None at line 238
     result = api.request("GET", "get_case/1")
 
     assert result is None
+
+
+def test_exc_deprecated_but_works(auth_data, mock, url):
+    with pytest.warns(DeprecationWarning, match="raise_on_error"):
+        api = TRApi(*auth_data, exc=True)
+    mock.add_callback(responses.GET, url("get_case/1"), lambda _: (400, {}, ""))
+    assert api.cases.get_case(1) is None
+
+
+def test_exc_false_deprecated_still_raises(auth_data, mock, url):
+    with pytest.warns(DeprecationWarning, match="raise_on_error"):
+        api = TRApi(*auth_data, exc=False)
+    mock.add_callback(responses.GET, url("get_case/1"), lambda _: (400, {}, ""))
+    with pytest.raises(StatusCodeError):
+        api.cases.get_case(1)
+
+
+def test_explicit_raise_on_error_wins_over_exc(auth_data, mock, url):
+    with pytest.warns(DeprecationWarning):
+        api = TRApi(*auth_data, exc=True, raise_on_error=True)
+    mock.add_callback(responses.GET, url("get_case/1"), lambda _: (400, {}, ""))
+    with pytest.raises(StatusCodeError):
+        api.cases.get_case(1)
+
+
+def test_unknown_constructor_kwarg_raises(auth_data):
+    with pytest.raises(TypeError):
+        TRApi(*auth_data, timout=60)  # typo of timeout must not be silently ignored
+
+
+def test_status_code_error_attributes(auth_data, mock, url):
+    api = TRApi(*auth_data)
+    mock.add_callback(responses.GET, url("get_case/1"), lambda _: (400, {}, "error body"))
+    with pytest.raises(StatusCodeError) as exc_info:
+        api.cases.get_case(1)
+    e = exc_info.value
+    assert e.status_code == 400
+    assert e.content == b"error body"
+    assert "get_case/1" in e.url
+    assert isinstance(e.response, Response)
+    # historical positional args layout is preserved
+    assert e.args == (e.status_code, e.reason, e.url, e.content)
+
+
+def test_get_params_are_not_mutated(api, mock, url):
+    mock.add_callback(responses.GET, url("get_cases/1"), lambda _: (200, {}, json.dumps({})))
+    created_after = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    params = {"created_by": [1, 2], "is_completed": True, "created_after": created_after}
+    api.get("get_cases/1", params=params)
+    assert params == {"created_by": [1, 2], "is_completed": True, "created_after": created_after}
+
+
+def test_get_params_conversion(api, mock, url):
+    def callback(request) -> tuple[int, dict, str]:
+        query = parse_qs(urlparse(request.url).query)
+        assert query["created_by"] == ["1,2"]
+        assert query["is_completed"] == ["1"]
+        assert query["type_id"] == ["1,2,3"]  # sets are sent in a deterministic order
+        return 200, {}, json.dumps({})
+
+    mock.add_callback(responses.GET, url("get_cases/1"), callback)
+    api.get("get_cases/1", params={"created_by": (1, 2), "is_completed": True, "type_id": {3, 1, 2}})
+
+
+def test_post_nested_datetime_converted(api, mock, url):
+    when = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    def callback(request) -> tuple[int, dict, str]:
+        body = json.loads(request.body)
+        assert body["results"][0]["custom_finished_on"] == round(when.timestamp())
+        return 200, {}, json.dumps([])
+
+    mock.add_callback(responses.POST, url("add_results/1"), callback)
+    results = [{"test_id": 1, "status_id": 1, "custom_finished_on": when}]
+    api.results.add_results(1, results)
+    # the caller's nested structure must stay untouched
+    assert results[0]["custom_finished_on"] is when
+
+
+def test_rate_limit_retry_after_http_date(api, mock, url):
+    http_date = format_datetime(datetime.now(timezone.utc) - timedelta(seconds=10), usegmt=True)
+    calls = {"count": 0}
+
+    def callback(_) -> tuple[int, dict, str]:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return 429, {"retry-after": http_date}, ""
+        return 200, {}, json.dumps({"id": 1})
+
+    mock.add_callback(responses.GET, url("get_case/1"), callback)
+    start = time.monotonic()
+    assert api.cases.get_case(1)["id"] == 1
+    assert calls["count"] == 2
+    assert time.monotonic() - start < 3  # past date clamps the delay to zero
+
+
+def test_rate_limit_retry_after_seconds(api, mock, url):
+    calls = {"count": 0}
+
+    def callback(_) -> tuple[int, dict, str]:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return 429, {"retry-after": "0"}, ""
+        return 200, {}, json.dumps({"id": 1})
+
+    mock.add_callback(responses.GET, url("get_case/1"), callback)
+    assert api.cases.get_case(1)["id"] == 1
+    assert calls["count"] == 2
+
+
+def test_bulk_rejects_limit_and_offset(api):
+    with pytest.raises(TypeError, match="managed automatically"):
+        api.cases.get_cases_bulk(1, limit=10)
+    with pytest.raises(TypeError, match="managed automatically"):
+        api.cases.get_cases_bulk(1, offset=10)
+
+
+def test_bulk_non_paginated_response():
+    mock_func = mock.Mock(return_value=[{"id": 1}])
+    with pytest.raises(TRApiError, match="paginated"):
+        _bulk_api_method(mock_func, "cases")
+
+
+def test_bulk_missing_key():
+    mock_func = mock.Mock(return_value={"offset": 0, "limit": 250, "size": 0})
+    with pytest.raises(TRApiError, match="'cases'"):
+        _bulk_api_method(mock_func, "cases")
+
+
+def test_bulk_null_page():
+    mock_func = mock.Mock(return_value={"offset": 0, "limit": 250, "size": 0, "cases": None})
+    assert _bulk_api_method(mock_func, "cases") == []
+
+
+def test_get_attachment_error_uses_custom_handler(auth_data, mock, url, tmp_path):
+    api = TRApi(*auth_data, response_handler=lambda _: "custom error")
+    mock.add_callback(responses.GET, url("get_attachment/1"), lambda _: (400, {}, ""))
+    assert api.attachments.get_attachment(1, tmp_path / "file.bin") == "custom error"
+    assert not (tmp_path / "file.bin").exists()
+
+
+def test_sensitive_headers_redacted_in_log(auth_data, caplog):
+    with caplog.at_level("INFO", logger="testrail_api"):
+        TRApi(*auth_data, headers={"Authorization": "top-secret", "X-Custom": "visible"})
+    assert "top-secret" not in caplog.text
+    assert "***" in caplog.text
+    assert "visible" in caplog.text


### PR DESCRIPTION
- Converters no longer mutate caller dicts; POST converter recurses into nested dicts/lists (datetime inside results payloads now works)
- Sets in GET params are serialized in deterministic order
- Retry: drop hardcoded KeyError, parse retry-after as seconds or HTTP-date, clamp delay to MAX_RATE_LIMIT_DELAY
- Deprecate 'exc' in favor of 'raise_on_error' (inverted meaning)
- StatusCodeError: attributes status_code/reason/url/content/response with backward-compatible positional args (closes #85)
- get_attachment: stream downloads in chunks, route error responses through the configured response_handler
- Redact sensitive headers in the session INFO log
- Explicit constructor parameters instead of **kwargs (typos now raise)
- _bulk_api_method: reject limit/offset, clear error on non-paginated responses, stop by page length instead of the fragile 'size' key
- Fix wrong return/param annotations in _category.py
- Deduplicate *_bulk docstrings